### PR TITLE
fix: inkview-eg example, skip applying pixels out of bounds

### DIFF
--- a/inkview-eg/src/lib.rs
+++ b/inkview-eg/src/lib.rs
@@ -43,6 +43,9 @@ impl DrawTarget for InkviewDisplay {
         for pixel in pixels {
             let x = pixel.0.x as usize;
             let y = pixel.0.y as usize;
+            if !(0..self.screen.width()).contains(&x) || !(0..self.screen.height()).contains(&y) {
+                continue;
+            }
             let color = pixel.1.luma();
             self.screen.draw(x, y, color);
         }

--- a/inkview-eg/src/lib.rs
+++ b/inkview-eg/src/lib.rs
@@ -5,11 +5,11 @@ use inkview::bindings;
 use inkview::screen::Screen;
 use std::convert::Infallible;
 
-pub struct InkViewDisplay {
+pub struct InkviewDisplay {
     screen: Screen<'static>,
 }
 
-impl InkViewDisplay {
+impl InkviewDisplay {
     pub fn new(iv: &'static bindings::inkview) -> Self {
         let screen = inkview::screen::Screen::new(iv);
 
@@ -25,13 +25,13 @@ impl InkViewDisplay {
     }
 }
 
-impl OriginDimensions for InkViewDisplay {
+impl OriginDimensions for InkviewDisplay {
     fn size(&self) -> Size {
         Size::new(self.screen.width() as u32, self.screen.height() as u32)
     }
 }
 
-impl DrawTarget for InkViewDisplay {
+impl DrawTarget for InkviewDisplay {
     type Color = Gray8;
 
     type Error = Infallible;

--- a/inkview-eg/src/lib.rs
+++ b/inkview-eg/src/lib.rs
@@ -43,9 +43,6 @@ impl DrawTarget for InkviewDisplay {
         for pixel in pixels {
             let x = pixel.0.x as usize;
             let y = pixel.0.y as usize;
-            if !(0..self.screen.width()).contains(&x) || !(0..self.screen.height()).contains(&y) {
-                continue;
-            }
             let color = pixel.1.luma();
             self.screen.draw(x, y, color);
         }

--- a/inkview-slint-demo/src/main.rs
+++ b/inkview-slint-demo/src/main.rs
@@ -62,11 +62,7 @@ fn main() {
                     let mut undo_stack = undo_stack.borrow_mut();
                     let window = window_weak.unwrap();
 
-                    model.push(ui::Circle {
-                        x: x as f32,
-                        y: y as f32,
-                        d: 30.0,
-                    });
+                    model.push(ui::Circle { x, y, d: 30.0 });
                     undo_stack.push(Change::CircleAdded {
                         row: model.row_count() - 1,
                     });
@@ -124,7 +120,7 @@ fn main() {
         }
     });
 
-    inkview::iv_main(&iv, {
+    inkview::iv_main(iv, {
         move |evt| {
             // println!("got evt: {:?}", evt);
 
@@ -134,11 +130,12 @@ fn main() {
                 }
             }
 
-            return Some(());
+            Some(())
         }
     })
 }
 
+#[allow(clippy::enum_variant_names)]
 enum Change {
     CircleAdded { row: usize },
     CircleRemoved { row: usize, circle: ui::Circle },

--- a/inkview-slint/src/lib.rs
+++ b/inkview-slint/src/lib.rs
@@ -133,7 +133,7 @@ impl slint::platform::Platform for Backend {
                     self.evts.recv().ok().and_then(ink_evt_to_slint)
                 };
 
-                if let Some(redraw_region) = dynamic_region_to_redraw.clone() {
+                if let Some(redraw_region) = dynamic_region_to_redraw {
                     if last_draw_at.elapsed() > Duration::from_millis(200) {
                         dynamic_region_to_redraw = None;
                         fulfill_dynamic_updates_after = None;
@@ -234,5 +234,5 @@ fn ink_evt_to_slint(evt: Event) -> Option<WindowEvent> {
         _ => return None,
     };
 
-    return Some(evt);
+    Some(evt)
 }

--- a/inkview/src/event.rs
+++ b/inkview/src/event.rs
@@ -2,8 +2,9 @@ use std::sync::Mutex;
 
 use crate::bindings::Inkview;
 
-static IV_EVENT_HANDLER: Mutex<Option<Box<dyn FnMut(Event) -> Option<()> + Send>>> =
-    Mutex::new(None);
+type IvEventHandlerType = Mutex<Option<Box<dyn FnMut(Event) -> Option<()> + Send>>>;
+
+static IV_EVENT_HANDLER: IvEventHandlerType = Mutex::new(None);
 
 pub fn iv_main<F: FnMut(Event) -> Option<()> + Send + 'static>(iv: &Inkview, handler: F) {
     unsafe {

--- a/inkview/src/lib.rs
+++ b/inkview/src/lib.rs
@@ -10,9 +10,6 @@ pub use event::*;
 pub fn load() -> bindings::Inkview {
     unsafe {
         let lib = libloading::Library::new("libinkview.so").unwrap();
-
-        let iv = bindings::Inkview::from_library(lib).unwrap();
-
-        iv
+        bindings::Inkview::from_library(lib).unwrap()
     }
 }

--- a/inkview/src/screen.rs
+++ b/inkview/src/screen.rs
@@ -43,6 +43,9 @@ impl<'a> Screen<'a> {
 
     #[inline(always)]
     pub fn draw(&mut self, x: usize, y: usize, c: u8) {
+        if !(0..self.width).contains(&x) || !(0..self.height).contains(&y) {
+            return;
+        }
         let i = self.stride * y + x;
 
         unsafe {

--- a/inkview/src/screen.rs
+++ b/inkview/src/screen.rs
@@ -14,7 +14,10 @@ pub struct Screen<'a> {
 
 impl<'a> Screen<'a> {
     pub fn new(iv: &'a Inkview) -> Self {
-        let fb = unsafe { iv.GetTaskFramebuffer(iv.GetCurrentTask()).as_mut().unwrap() };
+        let fb = unsafe { iv.GetTaskFramebuffer(iv.GetCurrentTask()).as_mut() };
+        let Some(fb) = fb else {
+            panic!("Failed to get current task framebuffer while creating new screen.");
+        };
 
         let width = fb.width as usize;
         let height = fb.height as usize;


### PR DESCRIPTION
This fixes the following things:
- the inkview-eg example. The display must be initialized only at the time or after the `Init` event is emitted, otherwise the app crashes sometimes.
- adds bounds checks before applying pixels to the framebuffer
- satisfy clippy