### PR TITLE
Forward Inkview Key Events to Slint

### DIFF
--- a/inkview-slint/src/lib.rs
+++ b/inkview-slint/src/lib.rs
@@ -1,3 +1,4 @@
+use inkview::event::Key;
 use inkview::{screen::Screen, Event};
 use rgb::RGB;
 use slint::platform::{
@@ -215,6 +216,26 @@ impl slint::platform::Platform for Backend {
     }
 }
 
+fn ink_key_to_slint(key: Key) -> Option<slint::platform::Key> {
+    match key {
+        Key::Up => Some(slint::platform::Key::UpArrow),
+        Key::Down => Some(slint::platform::Key::DownArrow),
+        Key::Left => Some(slint::platform::Key::LeftArrow),
+        Key::Prev => Some(slint::platform::Key::LeftArrow),
+        Key::Prev2 => Some(slint::platform::Key::LeftArrow),
+        Key::Right => Some(slint::platform::Key::RightArrow),
+        Key::Next => Some(slint::platform::Key::RightArrow),
+        Key::Next2 => Some(slint::platform::Key::RightArrow),
+        Key::Ok => Some(slint::platform::Key::Return),
+        Key::Back => Some(slint::platform::Key::Backspace),
+        Key::Menu => Some(slint::platform::Key::Menu),
+        Key::Home => Some(slint::platform::Key::Home),
+        Key::Plus => Some(slint::platform::Key::PageUp),
+        Key::Minus => Some(slint::platform::Key::PageDown),
+        _ => None,
+    }
+}
+
 fn ink_evt_to_slint(evt: Event) -> Option<WindowEvent> {
     println!("evt: {:?}", evt);
     let evt = match evt {
@@ -231,6 +252,33 @@ fn ink_evt_to_slint(evt: Event) -> Option<WindowEvent> {
         },
         Event::Foreground { .. } => WindowEvent::WindowActiveChanged(true),
         Event::Background { .. } => WindowEvent::WindowActiveChanged(false),
+        Event::KeyDown { key } => {
+            if let Some(slint_key) = ink_key_to_slint(key) {
+                WindowEvent::KeyPressed {
+                    text: slint_key.into(),
+                }
+            } else {
+                return None;
+            }
+        }
+        Event::KeyRepeat { key } => {
+            if let Some(slint_key) = ink_key_to_slint(key) {
+                WindowEvent::KeyPressRepeated {
+                    text: slint_key.into(),
+                }
+            } else {
+                return None;
+            }
+        }
+        Event::KeyUp { key } => {
+            if let Some(slint_key) = ink_key_to_slint(key) {
+                WindowEvent::KeyReleased {
+                    text: slint_key.into(),
+                }
+            } else {
+                return None;
+            }
+        }
         _ => return None,
     };
 


### PR DESCRIPTION
## Summary

This PR enables PocketBook hardware button events (Prev, Next, Menu, D-pad, etc.) to be forwarded to the Slint UI framework, allowing applications to handle physical key presses through Slint's standard event system.

## Changes Made

### Modified: `inkview-slint/src/lib.rs`

1. **Added `ink_key_to_slint()` function** - Maps PocketBook hardware keys to Slint key representations:

      | PocketBook Key | Slint Key |
      |----------------|-----------|
      | Up/Down/Left/Right | Arrow keys |
      | Prev/Prev2 | Left Arrow |
      | Next/Next2 | Right Arrow |
      | Plus | PageUp |
      | Minus | PageDown |
      | Ok | Return |
      | Back | Backspace |
      | Menu | Menu |
      | Home | Home |

3. **Extended `ink_evt_to_slint()` function** - Now handles keyboard events
   - Added handling for `Event::KeyDown` → `WindowEvent::KeyPressed`
   - Added handling for `Event::KeyRepeat` → `WindowEvent::KeyPressRepeated`
   - Added handling for `Event::KeyUp` → `WindowEvent::KeyReleased`
   - Unmapped keys are filtered out (returns `None`)

## Technical Details

Previously, key events from PocketBook hardware buttons were received by the `inkview` event system but ignored by the `inkview-slint` backend. The `ink_evt_to_slint()` function only converted pointer events (touch) and window state changes, returning `None` for all keyboard events.

Now, physical button presses flow through the complete event chain:
```
PocketBook Hardware → inkview → ink_evt_to_slint() → Slint WindowEvent → UI handlers
```

This allows Slint applications to handle keys using standard Slint patterns like:
```slint
FocusScope {
    key-pressed(event) => {
        if event.text == Key.PageDown {
            // Handle Minus button press
        }
    }
}
```

## Testing

- Tested that the code compiles successfully
- Tested on actual PocketBook hardware (Inkpad 3) to verify key event handling