### PR TITLE
fix: build recipes using different sdk version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
   build_and_test:
     name: Build rust
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         toolchain:
@@ -21,5 +21,9 @@ jobs:
           - sdk-6-8
     steps:
       - uses: actions/checkout@v4
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libfontconfig-dev
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose --no-default-features --features "${{ matrix.sdk }}" --all-targets

--- a/examples/inkview-slint-demo/Cargo.toml
+++ b/examples/inkview-slint-demo/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2021"
 euclid = "0.22.11"
 rgb = "0.8.52"
 slint = { version = "1.14.1", default-features = false, features = ["compat-1-2", "std", "software-renderer-systemfonts", "renderer-software"] }
-inkview = { path = "../../inkview", version = "0.2.0" }
-inkview-slint = { path = "../../inkview-slint", version = "0.2.0" }
+inkview = { path = "../../inkview", version = "0.2.0", default-features = false}
+inkview-slint = { path = "../../inkview-slint", version = "0.2.0", default-features = false}
 
 [build-dependencies]
 slint-build = { version = "1.14.1" }
 
 [features]
-default = []
+default = ["sdk-6-8"]
 sdk-5-19 = ["inkview/sdk-5-19"]
 sdk-6-5 = ["inkview/sdk-6-5"]
 sdk-6-8 = ["inkview/sdk-6-8"]

--- a/inkview-eg/Cargo.toml
+++ b/inkview-eg/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["flxzt"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-inkview = { path = "../inkview", version = "0.2.0" }
+inkview = { path = "../inkview", version = "0.2.0", default-features = false}
 embedded-graphics-core = "0.4.0"
 
 [dev-dependencies]
@@ -20,7 +20,7 @@ embedded-graphics = "0.8.1"
 anyhow = "1.0"
 
 [features]
-default = []
+default = ["sdk-6-8"]
 sdk-5-19 = ["inkview/sdk-5-19"]
 sdk-6-5 = ["inkview/sdk-6-5"]
 sdk-6-8 = ["inkview/sdk-6-8"]

--- a/inkview-slint/Cargo.toml
+++ b/inkview-slint/Cargo.toml
@@ -16,10 +16,10 @@ authors = ["Ben Simms"]
 euclid = "0.22.11"
 rgb = "0.8.52"
 slint = { version = "1.14.1", default-features = false, features = ["compat-1-2", "std", "software-renderer-systemfonts", "renderer-software"] }
-inkview = { path = "../inkview", version = "0.2.0" }
+inkview = { path = "../inkview", version = "0.2.0", default-features = false}
 
 [features]
-default = []
+default = ["sdk-6-8"]
 sdk-5-19 = ["inkview/sdk-5-19"]
 sdk-6-5 = ["inkview/sdk-6-5"]
 sdk-6-8 = ["inkview/sdk-6-8"]

--- a/justfile
+++ b/justfile
@@ -32,10 +32,12 @@ prerequisites:
     cargo install cargo-zigbuild
 
 build-app name:
-    cargo zigbuild --target {{zigbuild_target}} --profile {{cargo_profile}} -p {{name}} --features={{cargo_sdk_feature}}
+    cargo zigbuild --target {{zigbuild_target}} --profile {{cargo_profile}} -p {{name}} --no-default-features \
+        --features={{cargo_sdk_feature}}
 
 build-example crate name:
-    cargo zigbuild --target {{zigbuild_target}} --profile {{cargo_profile}} -p {{crate}} --example {{name}} --features={{cargo_sdk_feature}}
+    cargo zigbuild --target {{zigbuild_target}} --profile {{cargo_profile}} -p {{crate}} --example {{name}} \
+        --no-default-features --features={{cargo_sdk_feature}}
 
 # Transfer a built app to the device. 'path_to_binary' is a relative path from 'target/<build_target>/<cargo_out_profile>/'.
 transfer-app-usb path_to_binary target_app_name:


### PR DESCRIPTION
Need to explicitly disable default feature when using a different SDK version, otherwise the inkview crate will attempt to import multiple versions at the same time.