### PR TITLE
feat: ensure enabled wifi in helper scripts

### DIFF
--- a/utils/app-gdbserver.app
+++ b/utils/app-gdbserver.app
@@ -1,3 +1,19 @@
 #!/bin/sh
 
+# Ensure enabled Wifi
+if [ ! -d "/sys/class/net/eth0" ]; then
+  netagent net on
+fi
+dialog 1 "" "Connecting, please wait..." "" & sleep 1; kill "$!"
+# check connected to wifi network - device connects to last used and available network
+if test "$(cat /sys/class/net/eth0/carrier)" -e 0; then
+  sleep 5
+  while test "$(cat /sys/class/net/eth0/carrier)" -e 0; do
+    dialog 5 "" "Still attempting to connect to a wireless network!  Wait?" "Yes" "No"
+    if [ $? != 1 ]; then exit; fi
+    netagent connect
+    sleep 3
+  done
+fi
+
 gdbserver 0.0.0.0:10003 /mnt/ext1/applications/application.app

--- a/utils/app-receiver.app
+++ b/utils/app-receiver.app
@@ -2,6 +2,22 @@
 
 LOCAL_PORT=19991
 
+# Ensure enabled Wifi
+if [ ! -d "/sys/class/net/eth0" ]; then
+  netagent net on
+fi
+dialog 1 "" "Connecting, please wait..." "" & sleep 1; kill "$!"
+# check connected to wifi network - device connects to last used and available network
+if test "$(cat /sys/class/net/eth0/carrier)" -e 0; then
+  sleep 5
+  while test "$(cat /sys/class/net/eth0/carrier)" -e 0; do
+    dialog 5 "" "Still attempting to connect to a wireless network!  Wait?" "Yes" "No"
+    if [ $? != 1 ]; then exit; fi
+    netagent connect
+    sleep 3
+  done
+fi
+
 echo "Listening on :$LOCAL_PORT for application name.."
 LOCAL_APP_NAME=$(nc -l -p "$LOCAL_PORT" | tr -d ' ')
 echo "Received application name : '$LOCAL_APP_NAME'"

--- a/utils/ssh-dropbear-2468.app
+++ b/utils/ssh-dropbear-2468.app
@@ -7,5 +7,21 @@ if [ ! -f "/mnt/secure/su" ]; then
     dialog 3 "" "Device not rooted, can't start ssh server" "OK"
 fi
 
+# Ensure enabled Wifi
+if [ ! -d "/sys/class/net/eth0" ]; then
+  netagent net on
+fi
+dialog 1 "" "Connecting, please wait..." "" & sleep 1; kill "$!"
+# check connected to wifi network - device connects to last used and available network
+if test "$(cat /sys/class/net/eth0/carrier)" -e 0; then
+  sleep 5
+  while test "$(cat /sys/class/net/eth0/carrier)" -e 0; do
+    dialog 5 "" "Still attempting to connect to a wireless network!  Wait?" "Yes" "No"
+    if [ $? != 1 ]; then exit; fi
+    netagent connect
+    sleep 3
+  done
+fi
+
 echo "Starting SSH daemon (dropbear).."
 /mnt/secure/su /sbin/dropbear -p $port -G ""


### PR DESCRIPTION
This ensures WiFi gets enabled on startup in the helper script that need a network connection.
Resolves the issue that one always has to toggle the WiFi manually before launching these scripts.