### PR TITLE
Simple chores

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,3 +1,0 @@
-[build]
-pre-build = ["apt-get update && apt-get install --assume-yes --no-install-recommends libclang-dev clang libfontconfig1 fontconfig libfontconfig1-dev"]
-dockerfile = "./cross.Dockerfile"

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1776354588,
-        "narHash": "sha256-NOsJcVAG63emvdlQSpSGQjvHHxcGDfBHd/cgtpduerw=",
+        "lastModified": 1779284442,
+        "narHash": "sha256-89/KDnJGxTn3Na7dQ5Hn8UOoEzm/Ykct6NZn+ZDRP7U=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "d7aba90c41ee261d215cbe09cf92393cc0ff2606",
+        "rev": "bcd09e3fe07e143a4008f88b48789a373a19d09b",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
         "nixpkgs-src": "nixpkgs-src"
       },
       "locked": {
-        "lastModified": 1776348333,
-        "narHash": "sha256-ZyrYhlLGGuN5ieW7pE65meJJYnNz5el9vJtGBEJyDMQ=",
+        "lastModified": 1778507786,
+        "narHash": "sha256-HzSQCKMsMr8r55LwM1JuzIOB+8bzk0FEv6sItKvsfoY=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "efff47329167854ce48541c7ef731bf120753c7e",
+        "rev": "8f24a228a782e24576b155d1e39f0d914b380691",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
     "nixpkgs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1778274207,
+        "narHash": "sha256-I4puXmX1iovcCHZlRmztO3vW0mAbbRvq4F8wgIMQ1MM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "b3da656039dc7a6240f27b2ef8cc6a3ef3bccae7",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776481912,
-        "narHash": "sha256-Xq7p+Ex3YHFAd+fFFLOYw2Wv67582X7SAmrEDtIDZQ4=",
+        "lastModified": 1779247103,
+        "narHash": "sha256-DwltBoBl9a7fCzlKi3xnNha1NHbfvawwkNdnTXEyfFQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e611106c527e8ab0adbb641183cda284411d575c",
+        "rev": "86dbfb70dc1c2967245d87ed6d07d2c8bda305e3",
         "type": "github"
       },
       "original": {

--- a/test.nu
+++ b/test.nu
@@ -1,5 +1,0 @@
-#!/usr/bin/env nu
-
-cargo zigbuild --release --bin inkview-slint-demo --target armv7-unknown-linux-gnueabi.2.23 --features sdk-6-8
-scp -o HostKeyAlgorithms=+ssh-rsa target/armv7-unknown-linux-gnueabi/release/inkview-slint-demo root@192.168.1.113:/mnt/ext1/applications/slint.app.stage
-ssh -o HostKeyAlgorithms=+ssh-rsa root@192.168.1.113 'sh -c "killall slint.app; mv /mnt/ext1/applications/slint.app.stage /mnt/ext1/applications/slint.app; /mnt/ext1/applications/slint.app"'


### PR DESCRIPTION
I've noticed that `Cross.toml` and `test.nu` files are residual at this point; therefore, I took the liberty to clean them up.
And also, since the direnv was notifying about version updates, I've updated it along the way - the compilation of inkview-slint and inkview still works with no issues.