### PR TITLE
Closes #16: Add Discord server link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
   <a href="https://crates.io/crates/inkview"><img alt="Crates.io Version" src="https://img.shields.io/crates/v/inkview"></a>
   <a href="https://docs.rs/inkview/"><img alt="docs.rs" src="https://img.shields.io/docsrs/inkview"></a>
+  <a href="https://discord.gg/s4nprWTYqF"><img alt="Discord" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fdiscord.com%2Fapi%2Finvites%2Fs4nprWTYqF%3Fwith_counts%3Dtrue&query=%24.approximate_member_count&logo=discord&logoColor=white&color=green&label=Discord"></a>
 </p>
 
 


### PR DESCRIPTION
This MR adds a Discord server link that dynamically shows the number of community members.
~~On top of it, I took the liberty to add a logo for the crate's README, which I had to generate for the Discord server anyway.~~ (Removed)
@simmsb if you wish not to use the logo, or to change it to something else, feel free to do so :)