### PR TITLE
Two fixes for drawing into the global canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ just cargo_profile=release pb_device=PB632 deploy-usb inkview-slint-demo applica
 
 For more information take a look at [utils README.md](./utils/README.md)
 
+## Running without a device
+
+Some PocketBook SDK archives ship a **host x86_64 build of `libinkview.so`** beside the ARM one, and
+since `inkview` resolves its library by name at runtime rather than linking it, a build for
+`x86_64-unknown-linux-gnu` against that copy runs the real app on a desktop, in an X11 window.
+
+[inkview-rs-emu](https://github.com/ihrfv/inkview-rs-emu) packages that up — it builds, stages and
+runs any inkview-rs project against the SDK's host library, headless or windowed, and can drive the
+app with tap/swipe/key input. It is a separate project; nothing in this repo depends on it.
+
+It is not a device: e-ink refresh behaviour is only real on hardware. For questions that need the
+firmware itself, that project also documents running PocketBook firmware under
+[pbemu](https://codeberg.org/datyoma/pbemu).
+
 ## Bindings generation
 
 See documentation for the `generate-bindings` just recipe.

--- a/inkview-slint/src/lib.rs
+++ b/inkview-slint/src/lib.rs
@@ -71,17 +71,20 @@ impl slint::platform::Platform for Backend {
 
         let convert_evt = |evt| ink_evt_to_slint(scale_factor, evt);
 
-        slint::Window::set_size(
-            self.window.borrow().as_ref().unwrap().as_ref(),
-            slint::PhysicalSize::new(self.width as u32, self.height as u32)
-                .to_logical(scale_factor),
-        );
-
+        // The scale factor has to be announced before the size is set: `set_size`
+        // is resolved against the window's *current* scale, so sizing first makes
+        // slint record the logical size as the physical one and lay the UI out for
+        // a window of the wrong height.
         self.window
             .borrow()
             .as_ref()
             .unwrap()
             .dispatch_event(WindowEvent::ScaleFactorChanged { scale_factor });
+
+        slint::Window::set_size(
+            self.window.borrow().as_ref().unwrap().as_ref(),
+            slint::PhysicalSize::new(self.width as u32, self.height as u32),
+        );
 
         // bad naming, oops
         let mut fulfill_dynamic_updates_after: Option<Instant> = None;

--- a/inkview/src/screen.rs
+++ b/inkview/src/screen.rs
@@ -1,4 +1,4 @@
-use crate::bindings::APPLICATION_ATTRIBUTE_APPLICATION_READER;
+use crate::bindings::{APPLICATION_ATTRIBUTE_APPLICATION_READER, PANEL_FLAGS_PANEL_DISABLED};
 use crate::error;
 use crate::{bindings::icanvas_s, bindings::Inkview};
 use core::ffi::c_int;
@@ -64,6 +64,12 @@ impl<'a> Screen<'a> {
         let fb = unsafe {
             let task_fb = iv.GetTaskFramebuffer(iv.GetCurrentTask());
             if task_fb.is_null() {
+                // Once the panel is active the global canvas starts
+                // `PanelHeightFBOffset()` rows into the framebuffer, so anything
+                // drawn lands that far down the screen and the last rows wrap
+                // around to the top. The app declared itself a reader just
+                // above, so take the panel down and own the whole screen.
+                iv.SetPanelType(PANEL_FLAGS_PANEL_DISABLED as c_int);
                 iv.GetCanvas().as_mut()
             } else {
                 task_fb.as_mut()


### PR DESCRIPTION
While working on [inkview-rs-emu](https://github.com/ihrfv/inkview-rs-emu), the 2 bugs were detected in this (inkview-rs) repo that are related to scaling and resizing.

This PR provides the two fixes:

**`inkview-slint` announced the window size before the scale factor.** `Window::size()` then reported
331x480 for an 828x1200 screen, because the size was interpreted against a stale scale factor.
Rendering was already correct, so this only bites code that *reads* the window size — layout
decisions, hit-testing, anything sizing itself from `Window::size()`. Swapping the order fixes it.
This one is not emulator-specific at all.

**`Screen::new` left the panel up when falling back to `GetCanvas()`.** Once the panel is active, the
global canvas starts `PanelHeightFBOffset()` rows into the framebuffer while still reporting the full
height, so everything drawn lands that far down (75px at 828x1200) and the last rows wrap to the top.
`SetPanelType(PANEL_DISABLED)` on that path fixes it. It only shows up when drawing happens *after*
the `Init` handler — i.e. from the worker thread `inkview-slint` apps use — which is why it went
unnoticed.

Also adds a short README section pointing at the external emulator project, so the capability is
discoverable from here. Happy to drop that if you would rather the README stayed as it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)